### PR TITLE
.repo/project.list contains project paths, not project names

### DIFF
--- a/repo.bash_completion
+++ b/repo.bash_completion
@@ -132,13 +132,10 @@ _dir_completion() {
 }
 
 _project_completion() {
-    local repo_root=$(_find_repo)
-
-    if [ -n "${repo_root}" -a -f "${repo_root}/.repo/project.list" ]
-    then
-        local projects=$(cat "${repo_root}/.repo/project.list")
-        _gen_comps "${projects}"
-    fi
+    # Retrieve a list of all repo project names (as opposed to project paths)
+    local projects
+    projects=$(repo forall -c 'echo $REPO_PROJECT' 2>/dev/null)
+    _gen_comps "${projects}"
 }
 
 _manifest_completion() {


### PR DESCRIPTION
Hey, thanks for this script! Just wanted to make a quick fix,
to get a list of repo project names for bash completion, we use
the repo forall command instead of the .repo/project.list file.

Change-Id: I1752430e1d7a95ac50f4eb70d6183254602a8504
